### PR TITLE
Update base image to node:lts-stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:lts-stretch
 
-MAINTAINER Brian Sipple <@Brian_Sipple>
+LABEL maintainer="fabianscheidt@yahoo.de"
 
 # Update package index and install xvfb + chromium
 RUN apt-get update && apt-get install -y xvfb chromium

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:boron
+FROM node:lts-stretch
 
 MAINTAINER Brian Sipple <@Brian_Sipple>
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![dockeri.co][docker-badge-image]][docker-badge-url]
 
 
-_A Docker image that extends the [`node:boron` image](https://github.com/nodejs/docker-node#nodeversion)
+_A Docker image that extends the [`node:lts-stretch` image](https://github.com/nodejs/docker-node#nodeversion)
 and provides a binary for running a headless, WebGL-enabled Chromium browser
 inside of a Docker container_.
 
@@ -15,21 +15,21 @@ inside of a Docker container_.
 public [Docker Hub Registry](https://registry.hub.docker.com/):
 
   ```sh
-  docker pull bsipple/node-chromium-webgl
+  docker pull fabisch/node-chromium-webgl
   ```
 
   + Alternatively, you can build an image from the Dockerfile:
 
       ```sh
-      docker build -t="bsipple/node-chromium-webgl" github.com/BrianSipple/node-chromium-webgl
+      docker build -t="fabisch/node-chromium-webgl" github.com/fabianscheidt/node-chromium-webgl
       ```
 
 ### Usage
 
 ```sh
-docker run -it --rm bsipple/node-chromium-webgl /bin/bash
+docker run -it --rm fabisch/node-chromium-webgl /bin/bash
 ```
 
 
-[docker-badge-image]: http://dockeri.co/image/bsipple/node-chromium-webgl/
-[docker-badge-url]: https://hub.docker.com/r/bsipple/node-chromium-webgl/
+[docker-badge-image]: http://dockeri.co/image/fabisch/node-chromium-webgl/
+[docker-badge-url]: https://hub.docker.com/r/fabisch/node-chromium-webgl/


### PR DESCRIPTION
Hi!

I came across your image since I needed a way to run unit tests for WebGL components in Docker. Your solution still works wonderful, but the node version is somewhat outdated. Would you consider updating it?

Best, Fabian